### PR TITLE
WCP-318 : Fix email being used by Madison Portal

### DIFF
--- a/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/security/ConferenceUserPreAuthenticatedGrantedAuthoritiesUserDetailsService.java
+++ b/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/security/ConferenceUserPreAuthenticatedGrantedAuthoritiesUserDetailsService.java
@@ -28,9 +28,9 @@ public class ConferenceUserPreAuthenticatedGrantedAuthoritiesUserDetailsService 
     
     private ConferenceUserDao conferenceUserDao;
     private TransactionOperations transactionOperations;
-    private List<String> uniqueIdAttributeName = ImmutableList.of("uid");
-    private List<String> emailAttributeName = ImmutableList.of("wisceduallemails");
-    private List<String> displayNameAttributeName = ImmutableList.of("displayName");
+    private List<String> uniqueIdAttributeName;
+    private List<String> emailAttributeName;
+    private List<String> displayNameAttributeName;
 
     @Autowired
     public void setConferenceUserDao(ConferenceUserDao conferenceUserDao) {
@@ -42,7 +42,7 @@ public class ConferenceUserPreAuthenticatedGrantedAuthoritiesUserDetailsService 
         this.transactionOperations = transactionOperations;
     }
 
-    @Value("${emailAttributeName:wisceduallemails}")
+    @Value("${emailAttributeName:mail}")
     public void setEmailAttributeName(String emailAttributeName) {
         this.emailAttributeName = ImmutableList.copyOf(ATTRIBUTE_NAME_SEPERATOR.split(emailAttributeName));
     }

--- a/blackboardvc-portlet-webapp/src/main/webapp/WEB-INF/portlet.xml
+++ b/blackboardvc-portlet-webapp/src/main/webapp/WEB-INF/portlet.xml
@@ -106,6 +106,9 @@
         <name>wisceduallemails</name>
     </user-attribute>
     <user-attribute>
+        <name>mail</name>
+    </user-attribute>
+    <user-attribute>
         <name>eppn</name>
     </user-attribute>
     <user-attribute>


### PR DESCRIPTION
This makes mail default, then in the configuration/overlay properties file we will say wisceduallemails,mail
