### PR TITLE
WCP-345 : Adjusted the web service interface for telephony

### DIFF
--- a/blackboardvc-portlet-api/src/main/java/org/jasig/portlet/blackboardvcportlet/data/SessionTelephony.java
+++ b/blackboardvc-portlet-api/src/main/java/org/jasig/portlet/blackboardvcportlet/data/SessionTelephony.java
@@ -15,4 +15,5 @@ public interface SessionTelephony  extends Serializable{
 	boolean isPhone();
 	
 	long getTelephonyId();
+	Long getSessionId();
 }

--- a/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/dao/impl/SessionTelephonyDaoImpl.java
+++ b/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/dao/impl/SessionTelephonyDaoImpl.java
@@ -103,7 +103,7 @@ public class SessionTelephonyDaoImpl extends BaseJpaDao implements SessionTeleph
         
         //Remove the reference from the session to the recording
         
-        session.getSessionRecordings().remove(sessionTelephony);
+        session.getSessionTelephony().remove(sessionTelephony);
         
         final EntityManager entityManager = this.getEntityManager();
         entityManager.remove(sessionTelephony);

--- a/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/dao/impl/SessionTelephonyImpl.java
+++ b/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/dao/impl/SessionTelephonyImpl.java
@@ -157,4 +157,9 @@ public class SessionTelephonyImpl implements SessionTelephony {
 	public long getTelephonyId() {
 		return telephonyId;
 	}
+	
+	@Override
+	public Long getSessionId() {
+	    return session != null ? session.getSessionId() : null;
+	}
 }

--- a/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/mvc/sessionmngr/ManageTelephonyController.java
+++ b/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/mvc/sessionmngr/ManageTelephonyController.java
@@ -69,14 +69,14 @@ public class ManageTelephonyController {
 		        response.setRenderParameter("action", "viewSession");
 			} catch (SoapFaultClientException ex) {
 				if("Telephony is not enabled".equalsIgnoreCase(ex.getMessage())) {
-					response.setRenderParameter("error", "error.thirdPartyDisabled");
-					
-					
-					response.setPortletMode(PortletMode.EDIT);
-					response.setRenderParameter("action", "configureTelephony");
+					response.setRenderParameter("errorCode", "error.thirdPartyDisabled");
 				} else {
-					throw ex;
+				    //use the error message sent from BBC. In theory we shouldn't get here but we might.
+				    response.setRenderParameter("error", ex.getMessage());
 				}
+				
+                response.setPortletMode(PortletMode.EDIT);
+                response.setRenderParameter("action", "configureTelephony");
 			}
 			
 		}

--- a/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/mvc/sessionmngr/forms/TelephonyForm.java
+++ b/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/mvc/sessionmngr/forms/TelephonyForm.java
@@ -42,6 +42,8 @@ public class TelephonyForm implements SessionTelephony {
 	public void setChairPIN(String chairPIN) {
 		this.chairPIN = chairPIN;
 	}
+	
+	@NotBlank
 	public String getNonChairPhone() {
 		return nonChairPhone;
 	}
@@ -60,6 +62,8 @@ public class TelephonyForm implements SessionTelephony {
 	public void setPhone(boolean isPhone) {
 		this.isPhone = isPhone;
 	}
+	
+	@NotBlank
 	public String getSessionSIPPhone() {
 		return sessionSIPPhone;
 	}
@@ -80,10 +84,12 @@ public class TelephonyForm implements SessionTelephony {
 	public long getTelephonyId() {
 		return 0;
 	}
-	public long getSessionId() {
+	
+	@Override
+	public Long getSessionId() {
 		return sessionId;
 	}
-	public void setSessionId(long sessionId) {
+	public void setSessionId(Long sessionId) {
 		this.sessionId = sessionId;
 	}
 }

--- a/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/service/impl/SessionServiceImpl.java
+++ b/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/service/impl/SessionServiceImpl.java
@@ -697,15 +697,17 @@ public class SessionServiceImpl implements SessionService, ServletContextAware {
 	@Override
 	@PreAuthorize("hasRole('ROLE_ADMIN') || hasPermission(#sessionId, 'org.jasig.portlet.blackboardvcportlet.data.Session', 'edit')")
 	public void createOrUpdateSessionTelephony(long sessionId, SessionTelephony telephony) {
-		BlackboardSessionTelephonyResponse response = sessionWSDao.createSessionTelephony(sessionId, telephony);
+	    Session session = getSession(sessionId);
+		BlackboardSessionTelephonyResponse response = sessionWSDao.createSessionTelephony(session.getBbSessionId(), telephony);
 		sessionTelephonyDao.createOrUpdateTelephony(response);
 	}
 
 	@Override
 	@PreAuthorize("hasRole('ROLE_ADMIN') || hasPermission(#sessionId, 'org.jasig.portlet.blackboardvcportlet.data.Session', 'edit')")
 	public void deleteSessionTelephony(long sessionId) {
+	    Session session = getSession(sessionId);
 		//delete ws record
-		sessionWSDao.removeSessionTelephony(sessionId);
+		sessionWSDao.removeSessionTelephony(session.getBbSessionId());
 		//delete local db record
 		sessionTelephonyDao.deleteTelephony(sessionId);
 		

--- a/blackboardvc-portlet-webapp/src/main/webapp/WEB-INF/jsp/configureTelephony.jsp
+++ b/blackboardvc-portlet-webapp/src/main/webapp/WEB-INF/jsp/configureTelephony.jsp
@@ -42,8 +42,11 @@
   </thead>
 </table>
 <br/>
+<c:if test="${!empty errorCode }">
+	<div class="error"><spring:message code="${errorCode }" /></div>
+</c:if>
 <c:if test="${!empty error }">
-	<div class="error"><spring:message code="${error }" /></div>
+    <div class="error">${error }</div>
 </c:if>
 <portlet:actionURL portletMode="EDIT" var="saveTelephonyActionUrl">
   <portlet:param name="action" value="saveTelephony" />
@@ -65,10 +68,10 @@
 		  		<td><span class="uportal-channel-strong"><spring:message code="label.moderatorphone" text="Moderator Phone & PIN" /></span></td><td><form:input path="chairPhone" style="width: 12em;" class="uportal-input-text" /> <form:input path="chairPIN" style="width: 7em;" class="uportal-input-text" />&nbsp;<form:errors path="chairPhone" cssClass="error"/></td>
 		  	</tr>
 		  	<tr>
-		  		<td><span class="uportal-channel-strong"><spring:message code="label.participantphone" text="Participant Phone & PIN" /></span></td><td><form:input path="nonChairPhone" style="width: 12em;" class="uportal-input-text" /> <form:input path="nonChairPIN" style="width: 7em;" class="uportal-input-text" /></td>
+		  		<td><span class="uportal-channel-strong"><spring:message code="label.participantphone" text="Participant Phone & PIN" /></span></td><td><form:input path="nonChairPhone" style="width: 12em;" class="uportal-input-text" /> <form:input path="nonChairPIN" style="width: 7em;" class="uportal-input-text" />&nbsp;<form:errors path="nonChairPhone" cssClass="error"/></td>
 		  	</tr>
 		  	<tr>
-		  		<td><span class="uportal-channel-strong"><spring:message code="label.sipphone" text="SIP Phone & PIN" /></span></td><td><form:input path="sessionSIPPhone" style="width: 12em;" class="uportal-input-text" /> <form:input path="sessionPIN" style="width: 7em;" class="uportal-input-text" /></td>
+		  		<td><span class="uportal-channel-strong"><spring:message code="label.sipphone" text="SIP Phone & PIN" /></span></td><td><form:input path="sessionSIPPhone" style="width: 12em;" class="uportal-input-text" /> <form:input path="sessionPIN" style="width: 7em;" class="uportal-input-text" />&nbsp;<form:errors path="sessionSIPPhone" cssClass="error"/></td>
 		  	</tr>
 		  </tbody>
 	</table>

--- a/blackboardvc-portlet-webapp/src/test/java/org/jasig/portlet/blackboardvcportlet/dao/ws/impl/AbstractWSIT.java
+++ b/blackboardvc-portlet-webapp/src/test/java/org/jasig/portlet/blackboardvcportlet/dao/ws/impl/AbstractWSIT.java
@@ -129,7 +129,6 @@ public abstract class AbstractWSIT {
 
 			@Override
 			public String getNonChairPhone() {
-				// TODO Auto-generated method stub
 				return "1234567899";
 			}
 
@@ -157,6 +156,11 @@ public abstract class AbstractWSIT {
 			public long getTelephonyId() {
 				return 1;
 			}
+
+            @Override
+            public Long getSessionId() {
+                return Long.parseLong("1");
+            }
 		};
 		return tel;
 	}


### PR DESCRIPTION
There were a couple features we were unable to test while telephony was disabled on the Blackboard side.  Now that it is enabled we noticed some differences in our assumptions.
- non-chair phone is required
- SIP phone is required
- SIP phone has to be in a weird format (sip:foo@example.com)

I changed the errors that come back from bbc web services for telephony to display to the user for now as they are validation errors. There is a separate issue (WCP-344) to validate the data before it hits the web service.
