### PR TITLE
No name edit for you

### DIFF
--- a/blackboardvc-portlet-webapp/src/main/webapp/WEB-INF/jsp/createEditSession.jsp
+++ b/blackboardvc-portlet-webapp/src/main/webapp/WEB-INF/jsp/createEditSession.jsp
@@ -48,15 +48,15 @@
             <span class="uportal-channel-strong"><spring:message code="sessionName" text="sessionName"/></span>
         </td>
         <td>
-	        <c:choose>
-	          <c:when test="${sessionForm.newSession}">
-	            <form:input path="sessionName" style="width: 50%;" class="uportal-input-text" />&nbsp;&nbsp;<form:errors path="sessionName" cssClass="error"/>
-	          </c:when>
-	          <c:otherwise>
-	            <form:input type="hidden" path="sessionName" readonly="true"/>
-                  <c:out value="${sessionForm.sessionName}"/>
-	          </c:otherwise>
-	        </c:choose>
+            <c:choose>
+                <c:when test="${sessionForm.newSession}">
+                    <form:input path="sessionName" style="width: 50%;" class="uportal-input-text" />&nbsp;&nbsp;<form:errors path="sessionName" cssClass="error"/>
+                </c:when>
+            <c:otherwise>
+                <form:input type="hidden" path="sessionName" readonly="true"/>
+                <c:out value="${sessionForm.sessionName}"/>
+            </c:otherwise>
+            </c:choose>
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
[WCP-293](https://jira.doit.wisc.edu/jira/browse/WCP-293)

Requirements are to make sure the entire name displays on the edit session page and to display it as text, to not confuse anyone.

Two commits.  First is the work, second is code styling.

Before:
![image](https://cloud.githubusercontent.com/assets/5521429/2633724/ffb08e24-be71-11e3-9c66-6fdc55ecb290.png)
![image](https://cloud.githubusercontent.com/assets/5521429/2633733/140d4b78-be72-11e3-97e7-fa9745e6b605.png)

After:
![image](https://cloud.githubusercontent.com/assets/5521429/2633748/4d55ba28-be72-11e3-9357-07887f797985.png)
![image](https://cloud.githubusercontent.com/assets/5521429/2633752/585df9b2-be72-11e3-9926-a9b1c52789ac.png)
