### PR TITLE
WCP-396 : Automate recording datafix

### DIFF
--- a/blackboardvc-portlet-api/src/main/java/org/jasig/portlet/blackboardvcportlet/dao/JobMutexDao.java
+++ b/blackboardvc-portlet-api/src/main/java/org/jasig/portlet/blackboardvcportlet/dao/JobMutexDao.java
@@ -1,0 +1,22 @@
+package org.jasig.portlet.blackboardvcportlet.dao;
+
+import org.jasig.portlet.blackboardvcportlet.data.JobMutex;
+
+public interface JobMutexDao {
+  
+  JobMutex getJobMutex(String id);
+  /**
+   * checks if its in use, then puts it in use if not
+   * @param id the job id
+   * @param serverName the current servername
+   * @return returns true if started successfully, false if it failed
+   */
+  boolean startMutex(String id, String serverName);
+  
+  /**
+   * Stops the mutex. Puts an end date on the job id
+   * @param id the job to stop
+   * @return true if stopped successfully
+   */
+  boolean stopMutex(String id);
+}

--- a/blackboardvc-portlet-api/src/main/java/org/jasig/portlet/blackboardvcportlet/data/JobMutex.java
+++ b/blackboardvc-portlet-api/src/main/java/org/jasig/portlet/blackboardvcportlet/data/JobMutex.java
@@ -1,0 +1,14 @@
+package org.jasig.portlet.blackboardvcportlet.data;
+
+import org.joda.time.DateTime;
+
+public interface JobMutex {
+  //string id
+  String getId();
+  //string server name
+  String getServerName();
+  //date start time
+  DateTime getStartTime();
+  //date end time
+  DateTime getEndTime();
+}

--- a/blackboardvc-portlet-api/src/main/java/org/jasig/portlet/blackboardvcportlet/data/SessionRecording.java
+++ b/blackboardvc-portlet-api/src/main/java/org/jasig/portlet/blackboardvcportlet/data/SessionRecording.java
@@ -34,5 +34,7 @@ public interface SessionRecording extends Serializable {
     long getBbRecordingId();
 
     long getRecordingId();
+    
+    boolean isCreated();
 
 }

--- a/blackboardvc-portlet-api/src/main/java/org/jasig/portlet/blackboardvcportlet/service/RecordingService.java
+++ b/blackboardvc-portlet-api/src/main/java/org/jasig/portlet/blackboardvcportlet/service/RecordingService.java
@@ -18,6 +18,8 @@
  */
 package org.jasig.portlet.blackboardvcportlet.service;
 
+import java.net.UnknownHostException;
+
 import org.jasig.portlet.blackboardvcportlet.data.SessionRecording;
 import org.joda.time.DateTime;
 
@@ -44,5 +46,5 @@ public interface RecordingService {
      */
     int[] datafixRecordings(DateTime startDate, DateTime endDate);
 
-    void cronDatafixRecordings();
+    void cronDatafixRecordings() throws UnknownHostException;
 }

--- a/blackboardvc-portlet-api/src/main/java/org/jasig/portlet/blackboardvcportlet/service/RecordingService.java
+++ b/blackboardvc-portlet-api/src/main/java/org/jasig/portlet/blackboardvcportlet/service/RecordingService.java
@@ -28,13 +28,21 @@ import org.joda.time.DateTime;
  * @author Richard Good
  */
 public interface RecordingService {
-	void updateSessionRecordings(long sessionId, long startTime, long endTime);
-	
-	SessionRecording getSessionRecording(long recordingId);
-	
-	void updateSessionRecordingName(long recordingId, String roomName);
-	
-	void removeRecording(long recordingId);
-	
-	int datafixRecordings(DateTime startDate, DateTime endDate);
+    void updateSessionRecordings(long sessionId, long startTime, long endTime);
+    
+    SessionRecording getSessionRecording(long recordingId);
+    
+    void updateSessionRecordingName(long recordingId, String roomName);
+    
+    void removeRecording(long recordingId);
+    
+    /**
+     * Repairs local cache of recordings
+     * @param startDate The beginning date you wish to process
+     * @param endDate The end date you wish to process
+     * @return returns a int[3]. int[0] is number of recordings processed. int[1] is how many added to local cache. int[2] is how many erred.
+     */
+    int[] datafixRecordings(DateTime startDate, DateTime endDate);
+
+    void cronDatafixRecordings();
 }

--- a/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/dao/impl/JobMutexDaoImpl.java
+++ b/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/dao/impl/JobMutexDaoImpl.java
@@ -1,0 +1,65 @@
+package org.jasig.portlet.blackboardvcportlet.dao.impl;
+
+import org.jasig.jpa.BaseJpaDao;
+import org.jasig.portlet.blackboardvcportlet.dao.JobMutexDao;
+import org.jasig.portlet.blackboardvcportlet.data.JobMutex;
+import org.joda.time.DateTime;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+public class JobMutexDaoImpl  extends BaseJpaDao implements JobMutexDao {
+
+  @Override
+  public JobMutex getJobMutex(String id) {
+    return this.getEntityManager().find(JobMutexImpl.class, id);
+  }
+
+  private boolean createOrUpdateMutex(JobMutex jm) {
+    boolean created = false;
+    JobMutexImpl obj = this.getEntityManager().find(JobMutexImpl.class, jm.getId());
+    if(obj == null) {
+      created = true;
+      obj = new JobMutexImpl(jm.getId(), jm.getServerName());
+    }
+    obj.setServerName(jm.getServerName());
+    obj.setEndTime(jm.getEndTime());
+    obj.setStartTime(jm.getStartTime());
+    
+    this.getEntityManager().persist(obj);
+    return created;
+  }
+
+  private boolean createOrUpdateMutex(String id, String serverName) {
+    JobMutexImpl jm = new JobMutexImpl(id, serverName);
+    jm.setStartTime(DateTime.now());
+    return createOrUpdateMutex(jm);
+  }
+
+  @Override
+  @Transactional
+  public boolean startMutex(String id, String serverName) {
+    JobMutexImpl obj = this.getEntityManager().find(JobMutexImpl.class, id);
+    if(obj != null && obj.getEndTime() == null) {
+      return false; //already in use
+    } else {
+      //take it
+      createOrUpdateMutex(id, serverName);
+      return true;
+    }
+  }
+
+  @Override
+  @Transactional
+  public boolean stopMutex(String id) {
+    JobMutexImpl obj = this.getEntityManager().find(JobMutexImpl.class, id);
+    if(obj == null) {
+      logger.warn("Tried to end a mutex that didn't exist");
+      return false;
+    }
+    obj.setEndTime(DateTime.now());
+    this.getEntityManager().persist(obj);
+    return true;
+  }
+
+}

--- a/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/dao/impl/JobMutexImpl.java
+++ b/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/dao/impl/JobMutexImpl.java
@@ -2,15 +2,12 @@ package org.jasig.portlet.blackboardvcportlet.dao.impl;
 
 import java.io.Serializable;
 
-import javax.persistence.Cacheable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.persistence.Version;
 
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Type;
 import org.jasig.portlet.blackboardvcportlet.data.JobMutex;
 import org.joda.time.DateTime;
@@ -21,7 +18,7 @@ public class JobMutexImpl implements JobMutex, Serializable {
   private static final long serialVersionUID = 1L;
   
   @Id
-  @Column(name = "ID", nullable = false)
+  @Column(name = "ID", nullable = false, length = 30)
   private String id;
   
   @Column(name="SERVER_NAME", nullable = false)

--- a/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/dao/impl/JobMutexImpl.java
+++ b/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/dao/impl/JobMutexImpl.java
@@ -1,0 +1,92 @@
+package org.jasig.portlet.blackboardvcportlet.dao.impl;
+
+import java.io.Serializable;
+
+import javax.persistence.Cacheable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Version;
+
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.Type;
+import org.jasig.portlet.blackboardvcportlet.data.JobMutex;
+import org.joda.time.DateTime;
+
+@Entity
+@Table(name = "VC2_JOB_MUTEX")
+public class JobMutexImpl implements JobMutex, Serializable {
+  private static final long serialVersionUID = 1L;
+  
+  @Id
+  @Column(name = "ID", nullable = false)
+  private String id;
+  
+  @Column(name="SERVER_NAME", nullable = false)
+  private String serverName;
+  
+  @Column(name="START_DTE", nullable = false)
+  @Type(type = "dateTime")
+  private DateTime startTime;
+  
+  @Column(name="END_DTE")
+  @Type(type = "dateTime")
+  private DateTime endTime;
+  
+  @Version
+  @Column(name = "ENTITY_VERSION")
+  private final long entityVersion;
+  
+  /**
+   * needed by hibernate
+   */
+  @SuppressWarnings("unused")
+  private JobMutexImpl() {
+    entityVersion = -1;
+  }
+  
+  JobMutexImpl(String id, String serverName) {
+    this.id = id;
+    entityVersion = -1;
+    this.serverName = serverName;
+  }
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public String getServerName() {
+    return serverName;
+  }
+
+  @Override
+  public DateTime getStartTime() {
+    return startTime;
+  }
+
+  @Override
+  public DateTime getEndTime() {
+    return endTime;
+  }
+
+  public void setServerName(String serverName) {
+    this.serverName = serverName;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public void setEndTime(DateTime endTime) {
+    this.endTime = endTime;
+  }
+  
+  public void setStartTime(DateTime startTime) {
+    this.startTime = startTime;
+  }
+
+}

--- a/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/dao/impl/SessionRecordingDaoImpl.java
+++ b/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/dao/impl/SessionRecordingDaoImpl.java
@@ -74,6 +74,7 @@ public class SessionRecordingDaoImpl extends BaseJpaDao implements SessionRecord
         if (recording == null) {
             recording = new SessionRecordingImpl(bbRecordingId, session);
             logger.debug("Inserting new Recording for recording ID: " + bbRecordingId + " bbSessionId: " + session.getBbSessionId());
+            recording.setCreated(true);
         }
         
         recording.setCreationDate(DaoUtils.toDateTime(recordingLongResponse.getCreationDate()));

--- a/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/dao/impl/SessionRecordingImpl.java
+++ b/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/dao/impl/SessionRecordingImpl.java
@@ -10,6 +10,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.persistence.TableGenerator;
+import javax.persistence.Transient;
 import javax.persistence.Version;
 
 import org.apache.commons.io.FileUtils;
@@ -79,6 +80,9 @@ public class SessionRecordingImpl implements SessionRecording {
     @ManyToOne(targetEntity = SessionImpl.class, optional = false)
     @JoinColumn(name = "SESSION_ID", nullable = false)
     private final SessionImpl session;
+    
+    @Transient
+    private boolean created = false;
     
     /**
      * Needed by hibernate
@@ -178,6 +182,14 @@ public class SessionRecordingImpl implements SessionRecording {
 
     public void setRoomName(String roomName) {
         this.roomName = roomName;
+    }
+    
+    public boolean isCreated() {
+      return created;
+    }
+    
+    public void setCreated(boolean created) {
+      this.created = created;
     }
 
     @Override

--- a/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/mvc/admin/ViewAdminServerConfigController.java
+++ b/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/mvc/admin/ViewAdminServerConfigController.java
@@ -68,9 +68,10 @@ public class ViewAdminServerConfigController {
 	    DateTime ed = DateTime.parse(endDate, DateTimeFormat.forPattern("MM-dd-YYYY"));
 	    
 	    if(sd != null && ed != null) {
-	        int errd = recordingService.datafixRecordings(sd, ed);
-	        if(errd > 0)
-	            logger.warn("During datafixRecording, " + errd + " failed to insert");
+	        int[] status = recordingService.datafixRecordings(sd, ed);
+	        model.addAttribute("status", status);
+	        if(status[2] > 0)
+	            logger.warn("During datafixRecording, " + status[2] + " failed to insert");
 	    } else {
 	        response.setProperty(ResourceResponse.HTTP_STATUS_CODE, "400");
             response.setProperty("X-Status-Reason", "Validation failed");

--- a/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/service/impl/RecordingServiceImpl.java
+++ b/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/service/impl/RecordingServiceImpl.java
@@ -2,7 +2,6 @@ package org.jasig.portlet.blackboardvcportlet.service.impl;
 
 import java.util.List;
 
-import org.apache.commons.logging.Log;
 import org.jasig.portlet.blackboardvcportlet.dao.SessionRecordingDao;
 import org.jasig.portlet.blackboardvcportlet.dao.ws.RecordingWSDao;
 import org.jasig.portlet.blackboardvcportlet.data.SessionRecording;
@@ -12,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.support.DataAccessUtils;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -93,19 +93,48 @@ public class RecordingServiceImpl implements RecordingService {
     }
     
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    public int datafixRecordings(DateTime startDate, DateTime endDate) {
-       int countErred = 0;
+    @Override
+    public int[] datafixRecordings(DateTime startDate, DateTime endDate) {
+      return datafixRecordings(startDate, endDate, false);
+    }
+    
+    /**
+     * 
+     * @param startDate beginning datetime
+     * @param endDate end datetime
+     * @param cron ran from cron?
+     * @return returns a int[3]. int[0] is number of recordings processed. int[1] is how many added to local cache that were missing. int[2] is how many erred.
+     */
+    private int[] datafixRecordings(DateTime startDate, DateTime endDate, boolean cron) {
+       int[] returnArray = {0,0,0};
        //fetch the recording long information from the web service
         List<BlackboardRecordingLongResponse> recordingLongList = recordingWSDao.getRecordingLong(null, null, null, null, startDate.getMillis(), endDate.getMillis(), null);
+        returnArray[0] = recordingLongList != null ? recordingLongList.size() : 0;
         for(BlackboardRecordingLongResponse recordingResponse : recordingLongList) {
             try{
                 //post the information to the database
-                recordingDao.createOrUpdateRecording(recordingResponse);
+                SessionRecording recording = recordingDao.createOrUpdateRecording(recordingResponse);
+                if(recording.isCreated()) {
+                  returnArray[1]++;
+                }
             } catch (Exception ex) {
                 logger.error("Error adding datafix for recording: " + recordingResponse.getRecordingId() + " for session : " + recordingResponse.getSessionId(), ex);
-                countErred++;
+                returnArray[2]++;
             }
         }
-        return countErred;
+        return returnArray;
+    }
+    
+    /**
+     * Run cron job every day at 10am
+     */
+    @Scheduled(cron = "0 0 10 * * *")
+    @Override
+    public void cronDatafixRecordings() {
+      DateTime now = DateTime.now();
+      //run 2 days into the past, just in case yesterday ran
+      logger.debug("Ran job 'cronDatafixRecordings' on " + now);
+      int[] ret = datafixRecordings(now.minusDays(2), now, true);
+      logger.debug("Job 'cronDatafixRecordings' started: " + now + " and finished: " + DateTime.now() + ". Results: processed: "+ret[0]+" added : "+ret[1]+" erred: "+ret[2]+". See you tomorrow.");
     }
 }

--- a/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/service/impl/RecordingServiceImpl.java
+++ b/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/service/impl/RecordingServiceImpl.java
@@ -143,6 +143,7 @@ public class RecordingServiceImpl implements RecordingService {
     @Scheduled(cron = "0 0 10 * * *")
     @Override
     public void cronDatafixRecordings() throws UnknownHostException {
+      try {
       if(jobMutexDao.startMutex(RECORDING_DATA_FIX, InetAddress.getLocalHost().getHostName())) {
         DateTime now = DateTime.now();
         //run 2 days into the past, just in case yesterday ran
@@ -152,6 +153,10 @@ public class RecordingServiceImpl implements RecordingService {
         jobMutexDao.stopMutex(RECORDING_DATA_FIX);
       } else {
         logger.debug("Job " + RECORDING_DATA_FIX + " running on another server.");
+      }
+      } catch (Exception ex) {
+        logger.error("Issue running " + RECORDING_DATA_FIX + ". Going to attempt to stop mutex",ex);
+        jobMutexDao.stopMutex(RECORDING_DATA_FIX); //really try to stop it so it can run again next time
       }
     }
 }

--- a/blackboardvc-portlet-webapp/src/main/resources/hibernate.cfg.xml
+++ b/blackboardvc-portlet-webapp/src/main/resources/hibernate.cfg.xml
@@ -45,6 +45,7 @@
         
         <mapping class="org.jasig.portlet.blackboardvcportlet.dao.impl.ConferenceUserImpl"/>
         <mapping class="org.jasig.portlet.blackboardvcportlet.dao.impl.MultimediaImpl"/>
+        <mapping class="org.jasig.portlet.blackboardvcportlet.dao.impl.JobMutexImpl"/>
         <mapping class="org.jasig.portlet.blackboardvcportlet.dao.impl.PresentationImpl"/>
         <mapping class="org.jasig.portlet.blackboardvcportlet.dao.impl.SessionImpl"/>
         <mapping class="org.jasig.portlet.blackboardvcportlet.dao.impl.ServerConfigurationImpl"/>

--- a/blackboardvc-portlet-webapp/src/main/webapp/WEB-INF/jsp/recordingDatafix.jsp
+++ b/blackboardvc-portlet-webapp/src/main/webapp/WEB-INF/jsp/recordingDatafix.jsp
@@ -57,7 +57,7 @@
                 success: function (request, text){
                     $("#recordingGo").prop('disabled',false);
                     $('#loading').remove();
-                    $("#recordingGoButtonDiv").append('<span><div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>Datafix completed successfully.</div></span>');
+                    $("#recordingGoButtonDiv").append('<span><div class="alert alert-success alert-dismissable"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>Datafix completed successfully. Processed : '+ request.status[0] +'; Added Missing : '+ request.status[1] +'; Erred: '+ request.status[2] +'</div></span>');
                 },
                 error: function(request, text, error) {
                     //Leaving the Go button disabled on purpose.

--- a/blackboardvc-portlet-webapp/src/test/resources/jpaTestContext.xml
+++ b/blackboardvc-portlet-webapp/src/test/resources/jpaTestContext.xml
@@ -39,6 +39,7 @@
     <bean class="org.jasig.portlet.blackboardvcportlet.dao.impl.SessionRecordingDaoImpl" />
     <bean class="org.jasig.portlet.blackboardvcportlet.dao.impl.SessionTelephonyDaoImpl" />
     <bean class="org.jasig.portlet.blackboardvcportlet.dao.impl.UserSessionUrlDaoImpl" />
+    <bean class="org.jasig.portlet.blackboardvcportlet.dao.impl.JobMutexImpl"/>
     
                         
     <bean id="transactionManager" class="org.springframework.orm.jpa.JpaTransactionManager">


### PR DESCRIPTION
Makes a daily runner job for recording datafix. logs results. Runs everyday at 10am CT.

Also added more detail on the manual run. It now shows how many were processed, added, and erred.

New message : `Datafix completed successfully. Processed : 100; Added Missing : 20 Erred: 2`

Requires database change that DBA's need to do.
