### PR TITLE
WCP-410 : Add in session created successfully message

### DIFF
--- a/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/mvc/sessionmngr/SessionCreateEditController.java
+++ b/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/mvc/sessionmngr/SessionCreateEditController.java
@@ -203,7 +203,7 @@ public class SessionCreateEditController
 			response.setPortletMode(PortletMode.VIEW);
 	        response.setRenderParameter("sessionId", Long.toString(returnedSession.getSessionId()));
 	        response.setRenderParameter("action", "viewSession");
-	        response.setRenderParameter("newSessionMessage", Boolean.toString(session.isNewSession()));
+	        response.setRenderParameter("saveMessage", "true");
 		}
 	}
     

--- a/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/mvc/sessionmngr/SessionCreateEditController.java
+++ b/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/mvc/sessionmngr/SessionCreateEditController.java
@@ -199,8 +199,11 @@ public class SessionCreateEditController
 		else
 		{
 			final ConferenceUser conferenceUser = this.conferenceUserService.getCurrentConferenceUser();
-			this.sessionService.createOrUpdateSession(conferenceUser, session);
+			Session returnedSession = this.sessionService.createOrUpdateSession(conferenceUser, session);
 			response.setPortletMode(PortletMode.VIEW);
+	        response.setRenderParameter("sessionId", Long.toString(returnedSession.getSessionId()));
+	        response.setRenderParameter("action", "viewSession");
+	        response.setRenderParameter("newSessionMessage", Boolean.toString(session.isNewSession()));
 		}
 	}
     

--- a/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/mvc/sessionmngr/ViewSessionController.java
+++ b/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/mvc/sessionmngr/ViewSessionController.java
@@ -87,7 +87,7 @@ public class ViewSessionController
 	    @RequestParam long sessionId, 
 	    ModelMap model, 
 	    @RequestParam(required = false) String presentationUploadError,
-	    @RequestParam(required = false) String newSessionMessage)	{
+	    @RequestParam(required = false) String saveMessage)	{
     	
     	if(WindowState.NORMAL.equals(request.getWindowState())) {
 	        return viewController.view(request, model, null, null);
@@ -123,8 +123,8 @@ public class ViewSessionController
 			model.addAttribute("presentationUploadError", presentationUploadError);
 		}
         
-        if(newSessionMessage != null) {
-          model.addAttribute("newSessionMessage", newSessionMessage);
+        if(saveMessage != null) {
+          model.addAttribute("saveMessage", saveMessage);
         }
 
         return "viewSession";

--- a/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/mvc/sessionmngr/ViewSessionController.java
+++ b/blackboardvc-portlet-webapp/src/main/java/org/jasig/portlet/blackboardvcportlet/mvc/sessionmngr/ViewSessionController.java
@@ -82,10 +82,15 @@ public class ViewSessionController
     }
 
     @RenderMapping(params = "action=viewSession")
-	public String viewSession(PortletRequest request, @RequestParam long sessionId, ModelMap model, @RequestParam(required = false) String presentationUploadError)	{
+	public String viewSession(
+	    PortletRequest request, 
+	    @RequestParam long sessionId, 
+	    ModelMap model, 
+	    @RequestParam(required = false) String presentationUploadError,
+	    @RequestParam(required = false) String newSessionMessage)	{
     	
     	if(WindowState.NORMAL.equals(request.getWindowState())) {
-	    	return viewController.view(request, model, null, null);
+	        return viewController.view(request, model, null, null);
 	    }
     	
         final Session session = this.sessionService.getSession(sessionId);
@@ -117,6 +122,10 @@ public class ViewSessionController
 		{
 			model.addAttribute("presentationUploadError", presentationUploadError);
 		}
+        
+        if(newSessionMessage != null) {
+          model.addAttribute("newSessionMessage", newSessionMessage);
+        }
 
         return "viewSession";
 	}

--- a/blackboardvc-portlet-webapp/src/main/webapp/WEB-INF/jsp/viewSession.jsp
+++ b/blackboardvc-portlet-webapp/src/main/webapp/WEB-INF/jsp/viewSession.jsp
@@ -309,6 +309,14 @@
    });			
 })(blackboardPortlet.jQuery);
 </script>
+<c:if test="${newSessionMessage eq 'true' }">
+<script type="text/javascript">
+(function($) {
+    $('.blackboardVCRoot').before("<div class='blackboardVCRoot-notification-success'>Session created Successfully</div>");
+    $('.blackboardVCRoot-notification-success').click(function(){$('.blackboardVCRoot-notification-success').fadeOut();});
+})(up.jQuery);
+</script>
+</c:if>
 
 </div>
 </div>

--- a/blackboardvc-portlet-webapp/src/main/webapp/WEB-INF/jsp/viewSession.jsp
+++ b/blackboardvc-portlet-webapp/src/main/webapp/WEB-INF/jsp/viewSession.jsp
@@ -309,10 +309,10 @@
    });			
 })(blackboardPortlet.jQuery);
 </script>
-<c:if test="${newSessionMessage eq 'true' }">
+<c:if test="${saveMessage eq 'true' }">
 <script type="text/javascript">
 (function($) {
-    $('.blackboardVCRoot').before("<div class='blackboardVCRoot-notification-success'>Session created Successfully</div>");
+    $('.blackboardVCRoot').before("<div class='blackboardVCRoot-notification-success'>The web conference has been saved.</div>");
     $('.blackboardVCRoot-notification-success').click(function(){$('.blackboardVCRoot-notification-success').fadeOut();});
 })(up.jQuery);
 </script>

--- a/blackboardvc-portlet-webapp/src/main/webapp/css/portlet.css
+++ b/blackboardvc-portlet-webapp/src/main/webapp/css/portlet.css
@@ -283,3 +283,14 @@ li.ui-timepicker-selected .ui-timepicker-duration,
     text-align: left;
     
 }
+
+.blackboardVCRoot-notification-success {
+    border: 1px solid black;
+    border-radius: 5px;
+    margin-bottom: 10px;
+    text-align: center;
+    padding: 5px;
+    background-color: lightgreen;
+    font-weight: 600;
+    cursor: pointer;
+}


### PR DESCRIPTION
- Change behavior on save of edit or new session save so that is goes to "View Session"
- Add in notification on top to say it was saved successfully
  ![image](https://cloud.githubusercontent.com/assets/3534544/9793815/16e6e2f2-57ad-11e5-89d4-003b86ea7981.png)

Looks the same on classic and new
