### PR TITLE
Configure tests to use HSQL Hibernate dialect

### DIFF
--- a/blackboardvc-portlet-webapp/CHANGELOG.md
+++ b/blackboardvc-portlet-webapp/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Next (presumably 2.1.5)
 
 * Use Oracle10G Hibernate dialect, as declared in `hibernate.cfg.xml`,
-  to support database upgrade.
+  to support database upgrade, at runtime.
+  However, continue to use HSQL dialect in tests.
 
 ## 2.1.4 and earlier
 

--- a/blackboardvc-portlet-webapp/src/test/resources/jpaTestContext.xml
+++ b/blackboardvc-portlet-webapp/src/test/resources/jpaTestContext.xml
@@ -85,6 +85,7 @@
         <property name="persistenceUnitName" value="BlackboardCollaborateDb" />
         <property name="jpaProperties">
             <props>
+                <prop key="hibernate.dialect">org.hibernate.dialect.HSQLDialect</prop>
                 <prop key="hibernate.cache.use_query_cache">false</prop>
                 <prop key="hibernate.cache.use_second_level_cache">false</prop>
                 <prop key="persistenceUnitName">BlackboardCollaborateDb</prop>


### PR DESCRIPTION
Restores unit tests to passing by using the dialect for the local embedded database.